### PR TITLE
Change ユーザーID to ユーザー名.

### DIFF
--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -7,7 +7,7 @@
     <%= form_for(@user, url: signup_path) do |f| %>
       <%= render("shared/error_messages") %>
 
-      <%= f.label :name, "ユーザーID(必須項目)"%>
+      <%= f.label :name, "ユーザー名(必須項目)"%>
       <%= f.text_field :name, class: "form-control" %>
 
       <%= f.label :email, "メールアドレス(必須項目)" %>

--- a/app/views/users/settings_edit.html.erb
+++ b/app/views/users/settings_edit.html.erb
@@ -8,7 +8,7 @@
     <%= form_for(@user, url: settings_update_path(@user)) do |f| %>
       <%= render("shared/error_messages") %>
 
-      <%= f.label :name, "ユーザーID"%>
+      <%= f.label :name, "ユーザー名"%>
       <%= f.text_field :name, class: "form-control" %>
 
       <%= f.label :email, "メールアドレス" %>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe User, type: :model do
   let(:password_confirmation) { "abcdefgh" }
   let(:user) { User.new(name: name, email: email, password: password, password_confirmation: password_confirmation) }
 
-  # ユーザーID、Eメールアドレス、パスワードに問題がない場合、Userモデルのインスタンスが有効になる。
+  # ユーザー名、Eメールアドレス、パスワードに問題がない場合、Userモデルのインスタンスが有効になる。
   describe "An instance of the user model" do
     subject { user.valid? }
 


### PR DESCRIPTION
・モデルと入力フォームの名前がバラバラだったので、ユーザー名として統一