### PR TITLE
Book records

### DIFF
--- a/app/models/book_record.rb
+++ b/app/models/book_record.rb
@@ -1,3 +1,8 @@
 class BookRecord < ApplicationRecord
   belongs_to :user
+  validates(:user_id, presence: true)
+  validates(:type, presence: true)
+  validates(:category, presence: true)
+  validates(:amount, presence: true)
+  validates(:record_date, presence: true)
 end

--- a/app/models/book_record.rb
+++ b/app/models/book_record.rb
@@ -1,7 +1,7 @@
 class BookRecord < ApplicationRecord
   belongs_to :user
   validates(:user_id, presence: true)
-  validates(:type, presence: true)
+  validates(:direction, presence: true)
   validates(:category, presence: true)
   validates(:amount, presence: true)
   validates(:record_date, presence: true)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   attr_accessor :remember_token
+  has_many :book_records
   before_save { email.downcase! }
   mount_uploader :img, ImgUploader
   mount_uploader :header_image, HeaderImageUploader

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
   attr_accessor :remember_token
-  has_many :book_records
+  has_many :book_records, dependent: :destroy
   before_save { email.downcase! }
   mount_uploader :img, ImgUploader
   mount_uploader :header_image, HeaderImageUploader

--- a/db/migrate/20190926132232_rename_type_column_to_book_records.rb
+++ b/db/migrate/20190926132232_rename_type_column_to_book_records.rb
@@ -1,0 +1,5 @@
+class RenameTypeColumnToBookRecords < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :book_records, :type, :direction
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_24_142534) do
+ActiveRecord::Schema.define(version: 2019_09_26_132232) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "book_records", force: :cascade do |t|
-    t.integer "type"
+    t.integer "direction"
     t.integer "category"
     t.integer "amount"
     t.date "record_date"


### PR DESCRIPTION
・BookRecordモデルに対するバリデーションの追加
・BookRecordモデルのインスタンスがあるユーザーの存在に依存しているというルールを追加(destroyでユーザーを削除すると、紐づいたBookRecordインスタンスも削除される)。
・'type'という名前のカラムはActiveRecordと干渉するようなので、direction(お金の出入りの方向)というカラム名に変更