### PR TITLE
Blocking invalid configuration change requests.

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,7 @@
 class UsersController < ApplicationController
+  before_action :logged_in_user, only: [:settings_edit, :settings_update, :images_edit, :images_update, :images_reset]
+  before_action :correct_user, only: [:settings_edit, :settings_update, :images_edit, :images_update, :images_reset]
+
   def show
     @user = User.find_by(id: params[:id])
   end
@@ -73,5 +76,18 @@ class UsersController < ApplicationController
 
   def user_images_params
     params.require(:user).permit(:img, :header_image)
+  end
+
+  # before actions
+  def logged_in_user
+    return if logged_in?
+
+    flash[:danger] = "この操作にはログインが必要です。"
+    redirect_to(login_url)
+  end
+
+  def correct_user
+    @user = User.find(params[:id])
+    redirect_to(root_url) unless current_user?(@user)
   end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -33,6 +33,10 @@ module SessionsHelper
     end
   end
 
+  def current_user?(user)
+    user == current_user
+  end
+
   def logged_in?
     !current_user.nil?
   end


### PR DESCRIPTION
・非ログイン状態でユーザー設定画面に入ったり更新したりできないように。
・ログイン状態で自分以外のユーザー設定画面に入ったり更新したりできないように。

### 実装内容
#### `User model < before_action`の追加
- ログインしているかを判別する`logged_in_user`メソッド(private)
- アクセスしようとしているページが自分自身の`id`が割り振られているかを判別する`correct_user`メソッド(private)
#### `SessionsHelper < current_user?(user)`メソッドの追加
- `user`が現在ログインしているユーザーであれば`true`.
