### PR TITLE
The calendar is now displayed on the profile page.

### DIFF
--- a/app/views/shared/_calendar.html.erb
+++ b/app/views/shared/_calendar.html.erb
@@ -1,4 +1,4 @@
-<%= month_calendar(attribute: :record_date, events: current_user.daily_balances.all) do |date, balances| %>
+<%= month_calendar(attribute: :record_date, events: user.daily_balances.all) do |date, balances| %>
   <%= date.day %>
 
   <% balances.each do |balance| %>

--- a/app/views/static_pages/_home_logged_in.html.erb
+++ b/app/views/static_pages/_home_logged_in.html.erb
@@ -16,6 +16,6 @@
   </div>
   <div class="col-md-9 profile-information">
     <h1><%= "#{current_user.name}さんの#{Time.zone.now.strftime('%Y年%m月')}度収支" %></h1>
-    <%= render("shared/calendar") %>
+    <%= render("shared/calendar", user: current_user) %>
   <div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -16,6 +16,7 @@
     </div>
   </div>
   <div class="col-md-9 profile-information">
-    <h1>ここに色々な情報を入れる。</h1>
+    <h1><%= "#{@user.name}さんの#{Time.zone.now.strftime('%Y年%m月')}度収支" %></h1>
+    <%= render("shared/calendar", user: @user) %>
   <div>
 </div>


### PR DESCRIPTION
###  更新内容
- 収支カレンダーを各ユーザーのプロフィールページに表示。
- カレンダーのパーシャル(`app/views/shared/_calendar.html,erb`)をuserオブジェクトを用いるように変更